### PR TITLE
fix(docker): add cmake/make to build-deps for pycares wheel build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN apk add --no-cache --virtual .build-deps \
         musl-dev \
         python3-dev \
         libffi-dev \
-        openssl-dev && \
+        openssl-dev \
+        cmake \
+        make && \
     pip install --no-cache-dir -r requirements.txt && \
     apk del .build-deps
 


### PR DESCRIPTION
## Summary
- `pycares 5.0.0+` (now pulled in transitively via `aiodns >= 4.0.3`) uses **CMake** to build its bundled `c-ares`. Source build is forced on `linux/arm/v7` since no `musllinux_armv7l` wheel is published, and the missing CMake caused `build-and-push` to fail with `RuntimeError: CMake >= 3.5 is required to build pycares.`
- Adds `cmake` and `make` to the apk `.build-deps` virtual package — they're cleaned up in the same layer via `apk del .build-deps`, so the final image stays slim.

## Why now
`build-and-push` is currently red on `main` and on all four open dependabot PRs:
- #14 python-dotenv
- #15 tenacity
- #16 pytest-asyncio
- #17 aiodns

This is the common root cause for all of them.

## Test plan
- [ ] `lint-and-test` job still green
- [ ] `build-and-push` job green for all three platforms (linux/amd64, linux/arm64, linux/arm/v7)
- [ ] After merge, rebase the four dependabot PRs (\`@dependabot rebase\`) and confirm their builds go green